### PR TITLE
修复索引详情的列名“是否唯一索引”错误

### DIFF
--- a/src/components/order/orderSQLs.vue
+++ b/src/components/order/orderSQLs.vue
@@ -104,7 +104,7 @@ export default class orderSQLs extends Mixins(order_mixin) {
             key: 'IndexName'
         },
         {
-            title: '是否唯一索引',
+            title: '是否非唯一',
             key: 'NonUnique'
         },
         {


### PR DESCRIPTION
MySQL的`SHOW INDEX FROM
%s`语句的响应的列`Non_unique`，正确意思应为`是否非唯一索引`，但这个翻译有点冗长，故采用`是否非唯一`